### PR TITLE
refactor: sanity client to use sdk

### DIFF
--- a/utils/service/sanity-client.ts
+++ b/utils/service/sanity-client.ts
@@ -1,13 +1,8 @@
-import axios from "axios";
+import { client } from "../config/sanity-config.ts";
 
 export const generate_sanity_newsletter = async (date: string) => {
-  const encodedURI = encodeURIComponent(
-    `*[_type=="letter" && scheduled_post_date=="${date}"]{letter_info[]->{title,description,images},letter_fyi[]->{title,description},letter_title,letter_description,scheduled_post_date,letter_member_highlight, letter_tech_insights[]->{title,description}}`
-  );
+  const query = `*[_type=="letter" && scheduled_post_date=="${date}"]{letter_info[]->{title,description,images},letter_fyi[]->{title,description},letter_title,letter_description,scheduled_post_date,letter_member_highlight, letter_tech_insights[]->{title,description}}`;
 
-  const sanity_project_id = process.env.SANITY_PROJECT_ID ?? "";
-  const api_req = `https://${sanity_project_id}.api.sanity.io/v2021-10-21/data/query/production?query=${encodedURI}`;
-  const req = await axios.get(api_req);
-
-  return req.data.result[0];
+  const results = await client.fetch(query);
+  return results[0];
 };


### PR DESCRIPTION
This change ensures that we are caching responses that are made to the sanity API. This is a result of us now using the sanity CDN 