### PR TITLE
feat: adds multiple sentiments within one message

### DIFF
--- a/utils/helpers/thanks-helpers.ts
+++ b/utils/helpers/thanks-helpers.ts
@@ -63,7 +63,7 @@ export const sanitize_msg_lst = (msg: string) => {
 
   if (match === null) return [];
 
-  return match;
+  return match.map((match) => match.trim());
 };
 
 export const generate_user_id_receiver_array = (msg: string) => {


### PR DESCRIPTION
Users can now add multiple sentiments within one message. A sample message may look like the following:

```markdown
Hey @channel:sparkles:! We’re excited to announce a couple of changes to this channel to better support, !thanks @user1 @user2 for the V2 feedback that helped instigate the new change for the feedback that helped instigate new change.
This is a test message that is not relevant to the post but also !thanks @user3 for integrating the following feature.
```