### PR TITLE
feat: adds non-inclusive word detection

### DIFF
--- a/src/Events/inclusive.ts
+++ b/src/Events/inclusive.ts
@@ -1,0 +1,41 @@
+import app from "../../utils/config/slack-config.ts";
+import {
+  NON_INCLUSIVE_WORDS,
+  AXIOM_DATA_SET,
+} from "../../utils/constants/consts.ts";
+import { getRandomNumber } from "../../utils/helpers/generate-random-number.ts";
+import Axiom from "../../utils/config/axiom-config.ts";
+
+export const check_non_inclusive_words = () => {
+  app.message(NON_INCLUSIVE_WORDS, async ({ message, client }) => {
+    const msg = message as any;
+    const user_id_sender = msg.user as string;
+    const random_number = getRandomNumber(1, 5, false);
+    const respond_type_1 =
+      "How about 'friends' or 'everyone'? It's a small change that can make a big difference in creating a welcoming and inclusive environment for all :sparkles:";
+    const respond_type_2 =
+      "Have you considered 'y'all', or 'folks'? Let's make sure we create an inclusive community for everyone :blue_heart:";
+
+    if (random_number >= 3) {
+      const message_response = await client.chat.postEphemeral({
+        channel: msg.channel as string,
+        text: respond_type_1,
+        user: user_id_sender,
+      });
+
+      await Axiom.ingestEvents(AXIOM_DATA_SET, [
+        { inclusive_bot_message: { ok: message_response.ok } },
+      ]);
+    } else {
+      const message_response = await client.chat.postEphemeral({
+        channel: msg.channel as string,
+        text: respond_type_2,
+        user: user_id_sender,
+      });
+
+      await Axiom.ingestEvents(AXIOM_DATA_SET, [
+        { inclusive_bot_message: { ok: message_response.ok } },
+      ]);
+    }
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { thanks } from "../src/Events/thanks.ts";
 import { jokes } from "./Slash-commands/jokes.ts";
 import { suggestion } from "./Slash-commands/suggestions.ts";
 import { notify_admins } from "./Slash-commands/notify-admins.ts";
+import { check_non_inclusive_words } from "./Events/inclusive.ts";
 
 import { AXIOM_DATA_SET } from "../utils/constants/consts.ts";
 
@@ -45,6 +46,7 @@ greet_new_team_member();
 // );
 
 app_home_opened();
+check_non_inclusive_words();
 
 // Slash commands
 jokes();

--- a/utils/constants/consts.ts
+++ b/utils/constants/consts.ts
@@ -25,6 +25,7 @@ export const USER_ID_REGEX = /^U[A-Z0-9]{10}$/;
 
 export const GOOGLE_CALENDAR_ID = process.env.GOOGLE_CALENDAR_ID ?? "";
 export const GOOGLE_API_KEY = process.env.GOOGLE_CALENDAR_API_KEY ?? "";
+export const NON_INCLUSIVE_WORDS = /guys/i;
 
 export const TORONTO_TIME_ZONE_IDENTIFIER = "America/Toronto";
 


### PR DESCRIPTION
We've noticed that messages within public channels may contain messages with words that do not create an inclusive environment. This update allows Nemo to privately message users whenever they send a message that uses words which are not inclusive.