### PR TITLE
chore: adds char limit to coffee chat bio intro

### DIFF
--- a/utils/constants/shuffle-bot-bio-modal.ts
+++ b/utils/constants/shuffle-bot-bio-modal.ts
@@ -100,6 +100,7 @@ export const shuffle_bot_bio_modal = (
         element: {
           type: "plain_text_input",
           multiline: true,
+          max_length: 200,
           action_id: "intro-action",
           initial_value: initValues.intro,
         },


### PR DESCRIPTION
Adds a character limit to the coffee chat bio intro section. Members will now be limited to intros that are 200 chars in length.