### PR TITLE
fix: json schema for message blocks and send msg func

### DIFF
--- a/src/Events/shuffle_bot.ts
+++ b/src/Events/shuffle_bot.ts
@@ -52,13 +52,13 @@ export const coffee_chat_bot_shuffle = async () => {
   const today = new Date();
   today.setHours(6, 0);
 
-  const next_shuffle_date = international_timezone_formatter(
-    determine_next_execute_date_freq(
-      today,
-      "monday",
-      coffee_chat_config.shuffle_frequency
-    )
+  const next_shuffle_date = determine_next_execute_date_freq(
+    today,
+    "monday",
+    coffee_chat_config.shuffle_frequency
   );
+  const next_shuffle_date_formatted =
+    international_timezone_formatter(next_shuffle_date);
 
   const shuffled_new_users = shuffle_users(
     all_active_users_ids,
@@ -67,10 +67,7 @@ export const coffee_chat_bot_shuffle = async () => {
 
   try {
     await create_shuffle_groups(shuffled_new_users);
-    await update_next_shuffle_date(
-      SHUFFLE_SETTINGS_ID,
-      new Date(next_shuffle_date)
-    );
+    await update_next_shuffle_date(SHUFFLE_SETTINGS_ID, next_shuffle_date);
 
     await create_group_sendMsg(shuffled_new_users, all_active_users);
 
@@ -79,7 +76,7 @@ export const coffee_chat_bot_shuffle = async () => {
       id: channels.coffee_chat,
       input: {
         type: "blocks",
-        blocks: coffee_chat_shuffle_channel_msg(next_shuffle_date),
+        blocks: coffee_chat_shuffle_channel_msg(next_shuffle_date_formatted),
       },
       group: "channel",
     });

--- a/src/Events/shuffle_bot.ts
+++ b/src/Events/shuffle_bot.ts
@@ -288,6 +288,17 @@ export const coffee_chat_bio = () => {
           title: user_data.bio.title ?? "",
         }),
       });
+
+      await Axiom.ingestEvents(AXIOM_DATA_SET, [
+        {
+          coffee_chat_bot: {
+            channel: body.channel_id,
+            user_id: user_data.user_id,
+            user_name: body.user_name,
+            status: "Bio modal opened",
+          },
+        },
+      ]);
     } catch {
       await Axiom.ingestEvents(AXIOM_DATA_SET, [
         {
@@ -334,6 +345,15 @@ export const handle_coffee_chat_bio_submit = () => {
       };
 
       await update_shuffle_bot_bio(user_id, bio);
+      await Axiom.ingestEvents(AXIOM_DATA_SET, [
+        {
+          coffee_chat_bot: {
+            user_id: body.user.id,
+            user_name: body.user.name,
+            status: "Bio updated",
+          },
+        },
+      ]);
     } catch {
       await Axiom.ingestEvents(AXIOM_DATA_SET, [
         {

--- a/src/Events/shuffle_bot.ts
+++ b/src/Events/shuffle_bot.ts
@@ -72,13 +72,11 @@ export const coffee_chat_bot_shuffle = async () => {
     await create_group_sendMsg(shuffled_new_users, all_active_users);
 
     // post message in the channel that new groups have been made
-    await send_message({
-      id: channels.coffee_chat,
-      input: {
-        type: "blocks",
-        blocks: coffee_chat_shuffle_channel_msg(next_shuffle_date_formatted),
-      },
-      group: "channel",
+
+    await app.client.chat.postMessage({
+      channel: channels.coffee_chat,
+      text: "Members have been shuffled!!",
+      blocks: coffee_chat_shuffle_channel_msg(next_shuffle_date_formatted),
     });
 
     await Axiom.ingestEvents(AXIOM_DATA_SET, [

--- a/utils/constants/shuffle-bot-bio-modal.ts
+++ b/utils/constants/shuffle-bot-bio-modal.ts
@@ -173,7 +173,7 @@ export const shuffle_user_group_intro_msg = (
       text: {
         type: "plain_text",
         text: `Everyone, meet ${profile.user_name} (${
-          profile.bio.pronouns ?? ""
+          profile.bio.pronouns ?? "placeholder"
         }):`,
         emoji: true,
       },
@@ -182,23 +182,25 @@ export const shuffle_user_group_intro_msg = (
       type: "section",
       text: {
         type: "mrkdwn",
-        text: profile.bio.intro ?? "",
+        text: profile.bio.intro !== "" ? profile.bio.intro : "placeholder",
       },
       fields: [
         {
           type: "plain_text",
-          text: `:computer: ${profile.bio.title ?? ""}`,
+          text: `:computer: ${profile.bio.title ?? "placeholder"}`,
           emoji: true,
         },
         {
           type: "plain_text",
-          text: `:round_pushpin: ${profile.bio.location ?? ""}`,
+          text: `:round_pushpin: ${profile.bio.location ?? "placeholder"}`,
           emoji: true,
         },
       ],
       accessory: {
         type: "image",
-        image_url: profile.bio.img_url ?? "",
+        image_url:
+          profile.bio.img_url ??
+          "https://secure.gravatar.com/avatar/a506b0a0e7aef90663c21253c8b3f900.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0005-512.png",
         alt_text: "Profile picture",
       },
     },

--- a/utils/helpers/send-message.ts
+++ b/utils/helpers/send-message.ts
@@ -86,6 +86,7 @@ export const dm_lst_of_people = async (
         });
       } else {
         sent_message = await app.client.chat.postMessage({
+          text: "test",
           channel: channel.channel?.id ?? "",
           blocks: message.blocks,
         });


### PR DESCRIPTION
Fixes the JSON schema for the Slack message blocks (`shuffle_user_group_intro_msg`) in the `./constants/shuffle-bot-bio-modal.ts` file. 

Also, address the issue of sending messages to the group channel to notify participants that a shuffle has been completed.