### PR TITLE
chore: changes guppymail respond message

### DIFF
--- a/src/Slash-commands/guppymail.ts
+++ b/src/Slash-commands/guppymail.ts
@@ -37,10 +37,14 @@ export const guppymail = () => {
         ...message,
       });
 
+      const respond_message = is_anonymous
+        ? "Your message has been sent anonymously"
+        : "Your message has been sent";
+
       await respond({
         response_type: "ephemeral",
         mrkdwn: true,
-        text: "Your message has successfully been submitted!",
+        text: respond_message,
       });
 
       await Axiom.ingestEvents(AXIOM_DATA_SET, [


### PR DESCRIPTION
Changes the response message to say `Your message has been sent anonymously` if `!private` is used